### PR TITLE
npi and output table changes

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -49,7 +49,7 @@ models:
     +schema: staging
     core:
       +materialized: table
-      +schema: core
+      +schema: claims_preprocessing
 
 seeds:
   medicare_cclf_connector:

--- a/models/core/medical_claim.sql
+++ b/models/core/medical_claim.sql
@@ -23,7 +23,8 @@ select
   ,hcpcs_modifier_3
   ,hcpcs_modifier_4
   ,hcpcs_modifier_5
-  ,physician_npi
+  ,rendering_npi
+  ,billing_npi
   ,facility_npi
   ,paid_date
   ,paid_amount
@@ -160,7 +161,8 @@ select
   ,hcpcs_modifier_3
   ,hcpcs_modifier_4
   ,hcpcs_modifier_5
-  ,physician_npi
+  ,rendering_npi
+  ,billing_npi
   ,facility_npi
   ,paid_date
   ,paid_amount
@@ -297,7 +299,8 @@ select
   ,hcpcs_modifier_3
   ,hcpcs_modifier_4
   ,hcpcs_modifier_5
-  ,physician_npi
+  ,rendering_npi
+  ,billing_npi
   ,facility_npi
   ,paid_date
   ,paid_amount

--- a/models/transformation/dme_claims.sql
+++ b/models/transformation/dme_claims.sql
@@ -23,7 +23,8 @@ select
     ,cast(NULL as varchar) as hcpcs_modifier_3
     ,cast(NULL as varchar) as hcpcs_modifier_4
     ,cast(NULL as varchar) as hcpcs_modifier_5
-    ,cast(h.payto_prvdr_npi_num as varchar) as physician_npi
+    ,cast(h.ordrg_prvdr_npi_num as varchar) as rendering_npi
+    ,cast(h.payto_prvdr_npi_num as varchar) as billing_npi
     ,cast(NULL as varchar) as facility_npi
     ,cast(NULL as date) as paid_date
     ,cast(h.clm_line_cvrd_pd_amt as float) as paid_amount

--- a/models/transformation/institutional_claims.sql
+++ b/models/transformation/institutional_claims.sql
@@ -23,7 +23,8 @@ select
     ,cast(d.hcpcs_3_mdfr_cd as varchar) as hcpcs_modifier_3
     ,cast(d.hcpcs_4_mdfr_cd as varchar) as hcpcs_modifier_4
     ,cast(d.hcpcs_5_mdfr_cd as varchar) as hcpcs_modifier_5
-    ,cast(h.atndg_prvdr_npi_num as varchar) as physician_npi
+    ,cast(h.atndg_prvdr_npi_num as varchar) as rendering_npi
+    ,cast(null as varchar) as billing_npi
     ,cast(h.fac_prvdr_npi_num as varchar) as facility_npi
     ,cast(NULL as date) as paid_date
     ,cast(h.clm_pmt_amt as float) as paid_amount

--- a/models/transformation/physician_claims.sql
+++ b/models/transformation/physician_claims.sql
@@ -23,7 +23,8 @@ select
     ,cast(h.hcpcs_3_mdfr_cd as varchar) as hcpcs_modifier_3
     ,cast(h.hcpcs_4_mdfr_cd as varchar) as hcpcs_modifier_4
     ,cast(h.hcpcs_5_mdfr_cd as varchar) as hcpcs_modifier_5
-    ,cast(h.rndrg_prvdr_npi_num as varchar) as physician_npi
+    ,cast(h.rndrg_prvdr_npi_num as varchar) as rendering_npi
+    ,cast(NULL as varchar) as billing_npi
     ,cast(NULL as varchar) as facility_npi
     ,cast(NULL as date) as paid_date
     ,cast(clm_line_cvrd_pd_amt as float) as paid_amount


### PR DESCRIPTION
- changed the schema that tables output to 'claims_preprocessing' not core since the output of claims preprocessing is to core
- removed physician npi and replaced with rendering and billing after data model review