### PR TITLE
fixing revenue code for institutional claims

### DIFF
--- a/models/transformation/institutional_claims.sql
+++ b/models/transformation/institutional_claims.sql
@@ -19,7 +19,7 @@ select
         || {{ cast_string_or_varchar('h.clm_bill_freq_cd') }}
       as bill_type_code
     , {{ cast_string_or_varchar('h.dgns_drg_cd') }} as ms_drg_code
-    , {{ cast_string_or_varchar('d.clm_line_prod_rev_ctr_cd') }} as revenue_center_code
+    ,  lpad({{ cast_string_or_varchar('d.clm_line_prod_rev_ctr_cd') }},4,'0') as revenue_center_code
     , cast(d.clm_line_srvc_unit_qty as integer) as service_unit_quantity
     , {{ cast_string_or_varchar('d.clm_line_hcpcs_cd') }} as hcpcs_code
     , {{ cast_string_or_varchar('d.hcpcs_1_mdfr_cd') }} as hcpcs_modifier_1


### PR DESCRIPTION
## Describe your changes
Changing load of institutional claims to add leading zero for revenue code field. If revenue codes do not have leading zero then encounter table mappings are not working for institutional claims 

## How has this been tested?
Ran medicare_cclf_connector models and verified revenue_center_code field in medical_claim table 

## Reviewer focus

Please summarize the specific items you’d like the reviewer(s) to look into.

## Checklist before requesting a review

- [ ]  I have recorded a Loom performing a self-review of my code
- [1 ]  My code follows style guidelines
- [ ]  I have commented my code as necessary
- [ 1]  I have tested my code by running `dbt build` in the following warehouse(s):
    - [1 ]  Snowflake
    - [ ]  Redshift
- [ ]  I have implemented generic dbt tests to validate primary keys/uniqueness in my model
- [ ]  I have updated dbt docs by running `dbt docs generate` and copying the appropriate files to the `docs/` path
- [1 ]  I have added at least one Github label to this PR

## (Optional) Gif of how this PR makes you feel

![](url)

## Loom link

## For reviewers

[Best practices for reviewing pull requests.](https://www.notion.so/Pull-Request-Review-Best-Practices-b486354d76c04982889f2178fe777c1c)