### PR TITLE
Fixes issue with payer and plan causing financial_pmpm joins to miss

### DIFF
--- a/models/intermediate/dme_claims.sql
+++ b/models/intermediate/dme_claims.sql
@@ -4,8 +4,8 @@ select
     , 'professional' as claim_type
     , cast(bene_mbi_id as {{ dbt.type_string() }} ) as patient_id
     , cast(bene_mbi_id as {{ dbt.type_string() }} ) as member_id
-    , cast(NULL as {{ dbt.type_string() }} ) as payer
-    , cast(NULL as {{ dbt.type_string() }} ) as plan
+    , 'medicare' as payer
+    , 'medicare' as plan
     , {{ try_to_cast_date('clm_from_dt', 'YYYY-MM-DD') }} as claim_start_date
     , {{ try_to_cast_date('clm_thru_dt', 'YYYY-MM-DD') }} as claim_end_date
     , {{ try_to_cast_date('clm_line_from_dt', 'YYYY-MM-DD') }} as claim_line_start_date

--- a/models/intermediate/institutional_claims.sql
+++ b/models/intermediate/institutional_claims.sql
@@ -38,8 +38,8 @@ select
     , 'institutional' as claim_type
     , cast(h.bene_mbi_id as {{ dbt.type_string() }} ) as patient_id
     , cast(h.bene_mbi_id as {{ dbt.type_string() }} ) as member_id
-    , cast(NULL as {{ dbt.type_string() }} ) as payer
-    , cast(NULL as {{ dbt.type_string() }} ) as plan
+    , 'medicare' as payer
+    , 'medicare' as plan
     , {{ try_to_cast_date('h.clm_from_dt', 'YYYY-MM-DD') }} as claim_start_date
     , {{ try_to_cast_date('h.clm_thru_dt', 'YYYY-MM-DD') }} as claim_end_date
     , cast(NULL as date) as claim_line_start_date

--- a/models/intermediate/physician_claims.sql
+++ b/models/intermediate/physician_claims.sql
@@ -4,8 +4,8 @@ select
     , 'professional' as claim_type
     , cast(bene_mbi_id as {{ dbt.type_string() }} ) as patient_id
     , cast(bene_mbi_id as {{ dbt.type_string() }} ) as member_id
-    , cast(NULL as {{ dbt.type_string() }} ) as payer
-    , cast(NULL as {{ dbt.type_string() }} ) as plan
+    , 'medicare' as payer
+    , 'medicare' as plan
     , {{ try_to_cast_date('clm_from_dt', 'YYYY-MM-DD') }} as claim_start_date
     , {{ try_to_cast_date('clm_thru_dt', 'YYYY-MM-DD') }} as claim_end_date
     , {{ try_to_cast_date('clm_line_from_dt', 'YYYY-MM-DD') }} as claim_line_start_date


### PR DESCRIPTION
## Describe your changes

Fixes issue where payer and plan were causing joins to miss in the main project financial_pmpm tables.  This addresses issue #57 
The following tables were casting `null` as payer and plan, causing joins to not match in the main project's `financial_pmpm` schema.

* dme_claims
* instituational_claims
* physician_claims

This corrects the value to `medicare` as can be seen in the `eligibility` model [here](https://github.com/tuva-health/medicare_cclf_connector/blob/main/models/final/eligibility.sql#L146).


## How has this been tested?
After ensuring the `raw_cclf` schema is populated with data, run the following steps.
* `dbt build`
* `dbt run`
* Validate values in the `financial_pmpm.pmpm_prep`and `financial_pmpm.pmpm` are not all 0 values.


## Reviewer focus
Ensure `financial_pmpm.pmpm_prep` and `financial_pmpm.pmpm` values are not all 0 values.


## Checklist before requesting a review
- [ ]  (Optional) I have recorded a Loom performing a self-review of my code
- [x]  My code follows style guidelines
- [x]  I have commented my code as necessary
- [x]  (New models only) I have implemented generic dbt tests to validate primary keys/uniqueness in my model
- [ ]  I have added at least one Github label to this PR
