### PR TITLE
Use claim adjustment type code to determine if claim is a reversal

### DIFF
--- a/models/intermediate/dme_claims.sql
+++ b/models/intermediate/dme_claims.sql
@@ -31,7 +31,10 @@ select
     , cast(payto_prvdr_npi_num as {{ dbt.type_string() }} ) as billing_npi
     , cast(NULL as {{ dbt.type_string() }} ) as facility_npi
     , cast(NULL as date) as paid_date
-    , {{ cast_numeric('clm_line_cvrd_pd_amt') }} as paid_amount
+    , case
+        when cast(clm_adjsmt_type_cd as {{ dbt.type_string() }} ) = '1' then {{ cast_numeric('clm_line_cvrd_pd_amt') }} * -1
+        else {{ cast_numeric('clm_line_cvrd_pd_amt') }}
+      end as paid_amount
     , {{ cast_numeric('clm_line_alowd_chrg_amt') }} as allowed_amount
     , {{ cast_numeric('clm_line_alowd_chrg_amt') }} as charge_amount
     , {{ cast_numeric('NULL') }} as coinsurance_amount

--- a/models/intermediate/institutional_claims.sql
+++ b/models/intermediate/institutional_claims.sql
@@ -68,7 +68,10 @@ select
     , cast(NULL as {{ dbt.type_string() }} ) as billing_npi
     , cast(h.fac_prvdr_npi_num as {{ dbt.type_string() }} ) as facility_npi
     , cast(NULL as date) as paid_date
-    , {{ cast_numeric('a.paid_amount') }} as paid_amount
+    , case
+        when cast(h.clm_adjsmt_type_cd as {{ dbt.type_string() }} ) = '1' then {{ cast_numeric('a.paid_amount') }} * -1
+        else {{ cast_numeric('a.paid_amount') }}
+      end as paid_amount
     , {{ cast_numeric('NULL') }} as allowed_amount
     , {{ cast_numeric('h.clm_mdcr_instnl_tot_chrg_amt') }} as charge_amount
     , {{ cast_numeric('NULL') }} as coinsurance_amount

--- a/models/intermediate/physician_claims.sql
+++ b/models/intermediate/physician_claims.sql
@@ -31,7 +31,10 @@ select
     , cast(NULL as {{ dbt.type_string() }} ) as billing_npi
     , cast(NULL as {{ dbt.type_string() }} ) as facility_npi
     , cast(NULL as date) as paid_date
-    , {{ cast_numeric('clm_line_cvrd_pd_amt') }} as paid_amount
+    , case
+        when cast(clm_adjsmt_type_cd as {{ dbt.type_string() }} ) = '1' then {{ cast_numeric('clm_line_cvrd_pd_amt') }} * -1
+        else {{ cast_numeric('clm_line_cvrd_pd_amt') }}
+      end as paid_amount
     , {{ cast_numeric('clm_line_alowd_chrg_amt') }} as allowed_amount
     , {{ cast_numeric('clm_line_alowd_chrg_amt') }} as charge_amount
     , {{ cast_numeric('NULL') }} as coinsurance_amount


### PR DESCRIPTION
## Describe your changes
The [CMS guide](https://www.cms.gov/files/document/cclf-information-packet.pdf) has some literature on how to utilize claim adjustment type codes under the section `Calculating Beneficiary-Level Expenditures`.  It is possible to receive a claim reversal and the claim adjustment type code is how it's flagged.  This change ensures the paid amount considers this value to determine whether the paid amount should be a negative value or not.


## How has this been tested?
* Enable the features `claims_enabled` and `financial_pmpm_enabled`
* Load a data set that contains a claim reversal - in the parta_headers file, ensure `clm_adjsmt_type_cd` has a value of `1`
* `dbt build`
* `dbt run`
* Validate in `core.medical_claim` that the ingested claim has a negative value


## Reviewer focus
Ensure claim payment amount data looks accurate in core claims table.


## Checklist before requesting a review
- [ ]  (Optional) I have recorded a Loom performing a self-review of my code
- [x]  My code follows style guidelines
- [x]  I have commented my code as necessary
- [x]  (New models only) I have implemented generic dbt tests to validate primary keys/uniqueness in my model
- [ ]  I have added at least one Github label to this PR
