### PR TITLE
pad discharge disposition

### DIFF
--- a/models/intermediate/int_institutional_claim_deduped.sql
+++ b/models/intermediate/int_institutional_claim_deduped.sql
@@ -374,7 +374,7 @@ with sort_adjusted_claims as (
           end as discharge_date
         , clm_admsn_src_cd as admit_source_code
         , clm_admsn_type_cd as admit_type_code
-        , bene_ptnt_stus_cd as discharge_disposition_code
+        , right(concat('00', bene_ptnt_stus_cd), 2) as discharge_disposition_code
         , cast(null as {{ dbt.type_string() }} ) as place_of_service_code
         , {{ dbt.concat(
             [

--- a/models/intermediate/int_institutional_claim_deduped.sql
+++ b/models/intermediate/int_institutional_claim_deduped.sql
@@ -374,6 +374,7 @@ with sort_adjusted_claims as (
           end as discharge_date
         , clm_admsn_src_cd as admit_source_code
         , clm_admsn_type_cd as admit_type_code
+        /* make sure we get 2 digits for discharge disposition for readmissions mart*/ 
         , right(concat('00', bene_ptnt_stus_cd), 2) as discharge_disposition_code
         , cast(null as {{ dbt.type_string() }} ) as place_of_service_code
         , {{ dbt.concat(


### PR DESCRIPTION
## Describe your changes
See discussion here: https://thetuvaproject.slack.com/archives/C03DET9ETK3/p1742768100887689

Added the corresponding SQL on line 377 of `int_institutional_claim_deduped`. This should be a (relatively) straightforward PR. This should close #70 once merged.


## How has this been tested?
sanity checked a couple of examples provided in slack
e.g.
```sql
 select right(concat('00', 6), 2) as discharge_disposition_code
```

## Reviewer focus
Want to make sure these changes are portable

## Checklist before requesting a review
- [ ]  (Optional) I have recorded a Loom performing a self-review of my code
- [x]  My code follows style guidelines
- [x]  I have commented my code as necessary
- [ NA]  (New models only) I have implemented generic dbt tests to validate primary keys/uniqueness in my model
- [ ]  I have added at least one Github label to this PR

## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
