### PR TITLE
TUVA version and Eligibility schema upgrade

### DIFF
--- a/models/final/eligibility.sql
+++ b/models/final/eligibility.sql
@@ -105,7 +105,9 @@ with demographics as (
         , cast(demographics.bene_orgnl_entlmt_rsn_cd as {{ dbt.type_string() }} ) as original_reason_entitlement_code
         , cast(demographics.bene_dual_stus_cd as {{ dbt.type_string() }} ) as dual_status_code
         , cast(demographics.bene_mdcr_stus_cd as {{ dbt.type_string() }} ) as medicare_status_code
+        , cast(null as {{ dbt.type_string() }} ) as name_suffix
         , cast(demographics.bene_1st_name as {{ dbt.type_string() }} ) as first_name
+        , cast(demographics.bene_midl_name as {{ dbt.type_string() }} ) as middle_name
         , cast(demographics.bene_last_name as {{ dbt.type_string() }} ) as last_name
         , cast(null as {{ dbt.type_string() }} ) as social_security_number
         , cast('self' as {{ dbt.type_string() }} ) as subscriber_relation
@@ -128,6 +130,8 @@ with demographics as (
             ]
           ) }} as zip_code
         , cast(NULL as {{ dbt.type_string() }} ) as phone
+        , cast(NULL as {{ dbt.type_string() }} ) as email
+        , cast(NULL as {{ dbt.type_string() }} ) as ethnicity
         , 'medicare cclf' as data_source
         , cast(demographics.file_name as {{ dbt.type_string() }} ) as file_name
         , cast(demographics.file_date as {{ dbt.type_timestamp() }} ) as ingest_datetime
@@ -154,7 +158,9 @@ select
     , original_reason_entitlement_code
     , dual_status_code
     , medicare_status_code
+    , name_suffix
     , first_name
+    , middle_name
     , last_name
     , social_security_number
     , subscriber_relation
@@ -163,6 +169,8 @@ select
     , state
     , zip_code
     , phone
+    , email
+    , ethnicity
     , data_source
     , file_name
     , ingest_datetime

--- a/packages.yml
+++ b/packages.yml
@@ -2,4 +2,4 @@ packages:
   - package: dbt-labs/dbt_utils
     version: [">=0.9.2","<1.0.0"]
   - package: tuva-health/the_tuva_project
-    version: [">=0.13.0","<0.14.0"]
+    version: [">=0.15.0","<0.16.0"]


### PR DESCRIPTION
## Describe your changes
- The TUVA version has been upgraded to `v0.15`
- The additional fields: `name_suffix`, `middle_name`, `email`, and `ethnicity` has been added to eligibility model.
  - `name_suffix` has been set to `NULL`
  - `middle_name` has been pointed to `bene_midl_name`
  -  `email` has been set to `NULL`
  -  `ethnicity` has been set to `NULL`


## How has this been tested?
It has been tested using:
- dbt clean
- dbt deps


## Reviewer focus
- Please focus on `packages.yml` file for version upgrade
- Please focus towards additional fields on `models.final.eligibility.sql`


## Checklist before requesting a review
- [ ]  (Optional) I have recorded a Loom performing a self-review of my code
- [x]  My code follows style guidelines
- [ ]  I have commented my code as necessary
- [ ]  (New models only) I have implemented generic dbt tests to validate primary keys/uniqueness in my model
- [ ]  I have added at least one Github label to this PR

## (Optional) Gif of how this PR makes you feel
![](url)


## Loom link
